### PR TITLE
Hide Auto HVAC mode

### DIFF
--- a/.storage/lovelace.dashboard_remote
+++ b/.storage/lovelace.dashboard_remote
@@ -279,7 +279,13 @@
                   "entity": "climate.master_thermostat",
                   "features": [
                     {
-                      "type": "climate-hvac-modes"
+                      "type": "climate-hvac-modes",
+                      "hvac_modes": [
+                        "off",
+                        "cool",
+                        "heat",
+                        "fan_only"
+                      ]
                     }
                   ]
                 },
@@ -1373,7 +1379,13 @@
                       "entity": "climate.livingroom_thermostat",
                       "features": [
                         {
-                          "type": "climate-hvac-modes"
+                          "type": "climate-hvac-modes",
+                          "hvac_modes": [
+                            "off",
+                            "cool",
+                            "heat",
+                            "fan_only"
+                          ]
                         }
                       ]
                     },
@@ -1382,7 +1394,13 @@
                       "entity": "climate.kitchen_thermostat",
                       "features": [
                         {
-                          "type": "climate-hvac-modes"
+                          "type": "climate-hvac-modes",
+                          "hvac_modes": [
+                            "off",
+                            "cool",
+                            "heat",
+                            "fan_only"
+                          ]
                         }
                       ]
                     },
@@ -1391,7 +1409,13 @@
                       "entity": "climate.bedroom_thermostat",
                       "features": [
                         {
-                          "type": "climate-hvac-modes"
+                          "type": "climate-hvac-modes",
+                          "hvac_modes": [
+                            "off",
+                            "cool",
+                            "heat",
+                            "fan_only"
+                          ]
                         }
                       ]
                     },
@@ -1401,7 +1425,13 @@
                       "show_current_as_primary": false,
                       "features": [
                         {
-                          "type": "climate-hvac-modes"
+                          "type": "climate-hvac-modes",
+                          "hvac_modes": [
+                            "off",
+                            "cool",
+                            "heat",
+                            "fan_only"
+                          ]
                         }
                       ]
                     }

--- a/front_hvac_card.yaml
+++ b/front_hvac_card.yaml
@@ -12,6 +12,9 @@ cards:
       state: false
       mode: false
       fan: false
+    control:
+      hvac:
+        auto: false
     style: |
       ha-card {
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts available HVAC modes on thermostat cards and disables Auto mode on the front thermostat UI.
> 
> - **HVAC UI (Lovelace)**:
>   - Explicitly restrict thermostat `features` to `hvac_modes` = `["off", "cool", "heat", "fan_only"]` for `climate.master_thermostat`, `climate.livingroom_thermostat`, `climate.kitchen_thermostat`, `climate.bedroom_thermostat`, and `climate.bathroom_thermostat` in `.storage/lovelace.dashboard_remote`.
>   - Update `front_hvac_card.yaml` to disable Auto mode via `control.hvac.auto: false` on `custom:simple-thermostat` for `climate.front_thermostat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39e08af72faa4e47f3aaeac5d669892fce75b92f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->