### PR TITLE
Broaden ATS switch matching

### DIFF
--- a/configuration.template.yaml
+++ b/configuration.template.yaml
@@ -638,11 +638,13 @@ sensor:
           {% set switch_is_generator = (
             switch_pos in ['source 2', '2', 'secondary']
             or 'source 2' in switch_pos
+            or 'secondary' in switch_pos
             or 'generator' in switch_pos
           ) %}
           {% set switch_is_shore = (
             switch_pos in ['source 1', '1', 'primary']
             or 'source 1' in switch_pos
+            or 'primary' in switch_pos
             or 'shore' in switch_pos
             or 'utility' in switch_pos
           ) %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expand ATS switch position matching in `sensor.ac_source` to include substring matches for 'secondary' (generator) and 'primary' (shore).
> 
> - **Template Sensor `sensor.ac_source`**:
>   - Broaden ATS switch detection in `configuration.template.yaml`:
>     - `switch_pos` containing `secondary` now maps to generator.
>     - `switch_pos` containing `primary` now maps to shore.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39075c3964349d3a66715a611b1854bbe628a895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->