### PR TITLE
Tighten generator running detection

### DIFF
--- a/configuration.template.yaml
+++ b/configuration.template.yaml
@@ -649,8 +649,7 @@ sensor:
             or 'shore' in switch_pos
             or 'utility' in switch_pos
           ) %}
-          {% set generator_running = generator_state in ['running', 'on', 'starting', 'start']
-            or generator_switch == 'on' %}
+          {% set generator_running = generator_state in ['running', 'warmup', 'cooldown'] %}
           {% set inverter_inverting = inverter_valid and inverter_state in [
             'invert', 'inverting', 'waiting to invert', 'search'
           ] %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `generator_running` to rely on `sensor.generatorstatus` states `running`, `warmup`, and `cooldown`, removing switch-based and generic states.
> 
> - **Template sensor `ac_source` (in `configuration.template.yaml`)**:
>   - Refines `generator_running` logic to: `generator_state in ['running', 'warmup', 'cooldown']`.
>   - Removes reliance on `switch.generator` and prior states `on`, `starting`, `start`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d3b5fe31fa1f73b6bc684ec53aeaad84428d347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->