### PR TITLE
Expose RV-C temps on Systems view

### DIFF
--- a/.storage/lovelace.dashboard_remote
+++ b/.storage/lovelace.dashboard_remote
@@ -2870,6 +2870,10 @@
                 {
                   "entity": "sensor.processor_use",
                   "name": "Processor use"
+                },
+                {
+                  "entity": "sensor.rvc_temperature_debug",
+                  "name": "RV-C Temperature Codes"
                 }
               ],
               "title": "System Monitor"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `sensor.rvc_temperature_debug` to the Systems Monitor entities as "RV-C Temperature Codes".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a621b5069a36a5945e4f6c9739c6be17a9769699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->